### PR TITLE
Readme and naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ sudo usermod -aG docker ${USER}
 ```
 
 ### Clone this repo and build the Docker image
+
+You can also use built Docker images, see [ghcr.io/phantomcybernetics/phntm_bridge_client](https://github.com/PhantomCybernetics/phntm_bridge_client/pkgs/container/phntm_bridge_client) for ROS distributions and architectures.
+
 ```bash
 cd ~
 git clone git@github.com:PhantomCybernetics/phntm_bridge_client.git phntm_bridge_client
@@ -73,9 +76,9 @@ Full list of configuration options can be found [here](https://docs.phntm.io/bri
     id_robot: %ID_ROBOT%
     key: %SECRET_KEY%
     name: 'Unnamed Robot'
-    maintainer_email: 'robot.master@domain.com' # e-mail for service announcements
+    maintainer_email: 'robot.master@example.com' # e-mail for service announcements
 
-    cloud_bridge_address: https://us-ca.bridge.phntm.io
+    bridge_server_address: https://us-ca.bridge.phntm.io
 
     log_sdp: True # verbose WebRTC debug
     log_heartbeat: True # debug heartbeat
@@ -150,7 +153,8 @@ Add phntm_bridge service to your `~/compose.yaml` file with both `~/phntm_bridge
 ```yaml
 services:
   phntm_bridge:
-    image: phntm/bridge:humble
+    image: ghcr.io/phantomcybernetics/phntm_bridge_client:main-jazzy
+	# or phntm/bridge:$ROS_DISTRO if image is built locally locally
     container_name: phntm-bridge
     hostname: phntm-bridge.local
     restart: unless-stopped # restarts after first run

--- a/include/phntm_bridge/config.hpp
+++ b/include/phntm_bridge/config.hpp
@@ -27,7 +27,7 @@ namespace phntm {
             double discovery_period_sec, stop_discovery_after_sec;
             bool introspection_verbose;
 
-            std::string cloud_bridge_address, sio_path, uploader_address;
+            std::string bridge_server_address, sio_path, uploader_address;
             int file_upload_port, sio_port;
             bool sio_ssl_verify, sio_debug, sio_verbose;
             double sio_connection_retry_sec;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -134,7 +134,7 @@ namespace phntm {
         this->set_parameter(rclcpp::Parameter("ice_secret", "*************"));
         
         // Cloud Bridge host
-        this->declare_parameter("cloud_bridge_address", "https://us-ca.bridge.phntm.io");
+        this->declare_parameter("bridge_server_address", "https://us-ca.bridge.phntm.io");
         
         /// Cloud Bridge files uploader port
         this->declare_parameter("file_upload_port", 1336);
@@ -254,7 +254,7 @@ namespace phntm {
         config->log_message_every_sec = this->get_parameter("log_message_every_sec").as_double();
 
         // bloud bridge stuffs
-        config->cloud_bridge_address = this->get_parameter("cloud_bridge_address").as_string();
+        config->bridge_server_address = this->get_parameter("bridge_server_address").as_string();
         config->file_upload_port = this->get_parameter("file_upload_port").as_int();
         config->sio_port = this->get_parameter("sio_port").as_int();
         config->sio_path = this->get_parameter("sio_path").as_string();
@@ -262,11 +262,11 @@ namespace phntm {
         config->sio_debug = this->get_parameter("sio_debug").as_bool();
         config->sio_verbose = this->get_parameter("sio_verbose").as_bool();
         config->sio_connection_retry_sec = this->get_parameter("sio_connection_retry_sec").as_double();
-        if (config->cloud_bridge_address.empty()) {
-            RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Param cloud_bridge_address not provided!");
+        if (config->bridge_server_address.empty()) {
+            RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Param bridge_server_address not provided!");
             exit(1);
         }
-        config->uploader_address = fmt::format("{}:{}", config->cloud_bridge_address, config->file_upload_port);
+        config->uploader_address = fmt::format("{}:{}", config->bridge_server_address, config->file_upload_port);
 
         // conn LED control via topic (blinks when connecting; on when connected; off = bridge not running)
         this->declare_parameter("conn_led_topic", "");

--- a/src/sio.cpp
+++ b/src/sio.cpp
@@ -61,7 +61,7 @@ namespace phntm {
             return false;
         }
 
-        instance->socket_url = fmt::format("{}:{}{}", instance->config->cloud_bridge_address, instance->config->sio_port, instance->config->sio_path);
+        instance->socket_url = fmt::format("{}:{}{}", instance->config->bridge_server_address, instance->config->sio_port, instance->config->sio_path);
 
         RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Socket.io connecting to %s", instance->socket_url.c_str());
 


### PR DESCRIPTION
Last part of renaming cloud_bridge to bridge_server: cloud_bridge_address -> bridge_server_address

Few updates:
- mention docker images in readme
- robot.master@domain.com -> robot.master@example.com (example.com is domain reserved for examples, domain.com is owned by somebody)

