### PR TITLE
Disable build for `rolling`

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -26,14 +26,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: amd64
-            ros_distro: rolling
-            runner: ubuntu-latest
-            platform: linux/amd64
-          - arch: arm64
-            ros_distro: rolling
-            runner: ubuntu-24.04-arm
-            platform: linux/arm64
+          # - arch: amd64
+          #   ros_distro: rolling
+          #   runner: ubuntu-latest
+          #   platform: linux/amd64
+          # - arch: arm64
+          #   ros_distro: rolling
+          #   runner: ubuntu-24.04-arm
+          #   platform: linux/arm64
 
           - arch: amd64
             ros_distro: kilted


### PR DESCRIPTION
@mirek-burkon the docker build for `rolling` distro is failing, lets disable it so that we don't become blind to build failures of other distros?